### PR TITLE
Add missing bracket to css that was removed during previous merge

### DIFF
--- a/plugins/uploaders/svg2laser/css/plugin.css
+++ b/plugins/uploaders/svg2laser/css/plugin.css
@@ -110,8 +110,8 @@
 
 #svg2laser #passes div.input-group {
     flex-wrap: nowrap;
+}
 
-  
 #svg2laser #passes tr.pass-settings {
     outline: 2px solid transparent;
     outline-offset: -1px;


### PR DESCRIPTION
Somehow when the previous two pulls were merged a single bracket went missing which broke the css parser towards the end so the `:hover` border highlighting of the table rows didn't work.