### PR TITLE
Add ability to drag and drop files to upload

### DIFF
--- a/plugins/uploaders/svg2laser/css/plugin.css
+++ b/plugins/uploaders/svg2laser/css/plugin.css
@@ -110,8 +110,8 @@
 
 #svg2laser #passes div.input-group {
     flex-wrap: nowrap;
+}
 
-  
 #svg2laser #passes tr.pass-settings {
     outline: 2px solid transparent;
     outline-offset: -1px;

--- a/www/include/css/app.css
+++ b/www/include/css/app.css
@@ -1,125 +1,150 @@
 @font-face {
-  font-family: Lato;
-  src: url(fonts/Lato-Regular.ttf);
+    font-family: Lato;
+    src: url(fonts/Lato-Regular.ttf);
 }
 
 @keyframes fadeIn {
-  from {
-    opacity: 0;
-  }
+    from {
+        opacity: 0;
+    }
 
-  to {
-    opacity: 1;
-  }
+    to {
+        opacity: 1;
+    }
 }
 
 .fade {
-  animation: fadeIn 1s;
+    animation: fadeIn 1s;
 }
 
 body {
-  padding-top: 65px;
-  font-family: Lato;
+    padding-top: 65px;
+    font-family: Lato;
+    height: 100vh;
+}
+
+body::before {
+    content: "Drop file anywhere to upload";
+    display: none;
+    position: absolute;
+    --padding-size: 10px;
+    top: var(--padding-size);
+    bottom: var(--padding-size);
+    left: var(--padding-size);
+    right: var(--padding-size);
+    z-index: 9999; /* Ensures the border is above all other elements */
+    border: 3px dashed #55995b;
+    pointer-events: none; /* Prevents interference with other elements */
+
+    /* Centering text with flexbox */
+    justify-content: center; /* Horizontal centering */
+    align-items: center; /* Vertical centering */
+    text-align: center; /* For multiline text */
+    font-size: 20px; /* Adjust the font size as required */
+}
+
+body.dragover::before {
+    display: flex;
 }
 
 #cncfm-nav {
-  padding-top: 5px;
-  padding-bottom: 5px;
+    padding-top: 5px;
+    padding-bottom: 5px;
 }
 
 .form-control {
-  border-radius: 3px;
+    border-radius: 3px;
 }
 
 .btn {
-  border-radius: 4px;
+    border-radius: 4px;
 }
 
 #cncfm-files tbody tr:nth-child(2n + 1) {
-  background-color: #fafafa;
+    background-color: #fafafa;
 }
 
 #cncfm-files tbody tr {
-  cursor: pointer;
-  font-size: 1.2em;
+    cursor: pointer;
+    font-size: 1.2em;
 }
 
 .cncfm-files-directory td {
-  font-weight: 700;
-  color: #000;
-  padding: 10px;
-  line-height: 25px;
+    font-weight: 700;
+    color: #000;
+    padding: 10px;
+    line-height: 25px;
 }
 
 .cncfm-files-file td {
-  padding: 10px;
-  color: #555;
+    padding: 10px;
+    color: #555;
 }
 
 table.table * {
-  border: 0;
-  border-bottom: 0 !important;
+    border: 0;
+    border-bottom: 0 !important;
 }
 
 table.table th {
-  font-size: 12px;
-  letter-spacing: 2px;
+    font-size: 12px;
+    letter-spacing: 2px;
 }
 
 #cncfm-files-header {
-  font-size: 1.5em;
-  overflow: hidden;
+    font-size: 1.5em;
+    overflow: hidden;
 }
 
 #cncfm-files-header a {
-  text-decoration: none;
-  color: #333;
+    text-decoration: none;
+    color: #333;
 }
 
 #cncfm-upload-form {
-  width: 0px;
-  height: 0px;
-  overflow: hidden;
+    width: 0px;
+    height: 0px;
+    overflow: hidden;
 }
 
 #cncfm-job-content-table {
-  width: 800px;
+    width: 800px;
 }
 
 #cncfm-job-running {
-  height: 100px;
-  filter: grayscale(1);
+    height: 100px;
+    filter: grayscale(1);
 }
 
 #cncfm-job-queued {
-  font-size: 100px;
+    font-size: 100px;
 }
 
 #cncfm-job-bug {
-  font-size: 100px;
+    font-size: 100px;
 }
 
 #cncfm-job-options-content {
-  background-color: #eee;
-  border-color: #aaa;
-  border-style: solid;
-  border-width: 1px;
-  border-radius: 10px;
-  padding: 10px;
+    background-color: #eee;
+    border-color: #aaa;
+    border-style: solid;
+    border-width: 1px;
+    border-radius: 10px;
+    padding: 10px;
 }
 
 #cncfm-job-logs-content {
-  width: 750px;
-  overflow: scroll;
-  white-space: pre;
-  background-color: #eee;
-  border-color: #aaa;
-  border-style: solid;
-  border-width: 1px;
-  border-radius: 10px;
-  padding: 10px;
+    width: 750px;
+    overflow: scroll;
+    white-space: pre;
+    background-color: #eee;
+    border-color: #aaa;
+    border-style: solid;
+    border-width: 1px;
+    border-radius: 10px;
+    padding: 10px;
 }
 
 #cncfm-uploader-content {
-  padding-bottom: 100px;
+    padding-bottom: 100px;
 }

--- a/www/include/css/app.css
+++ b/www/include/css/app.css
@@ -43,6 +43,20 @@ body::before {
     font-size: 20px; /* Adjust the font size as required */
 }
 
+body.dragover::after {
+    content: "";
+    display: block;
+    position: fixed;
+    top: 0;
+    bottom: 0;
+    left: 0;
+    right: 0;
+    background-color: #3e3e3e17;
+    -webkit-backdrop-filter: blur(5px);
+    backdrop-filter: blur(5px);
+    z-index: 9998; /* Lower than the z-index of the ::before pseudo-element */
+}
+
 body.dragover::before {
     display: flex;
 }

--- a/www/include/js/app.plugins.uploaders.js
+++ b/www/include/js/app.plugins.uploaders.js
@@ -20,32 +20,40 @@ class cncfmPluginsUploaders {
             cncfm.uploaders.active.upload();
         });
 
-        $(document).on("change", "#fileUpload", function (e) {
-            let f = e.target.files[0];
-            cncfm.uploaders.f = f;
-            var u = cncfm.uploaders.get(f);
-            if (u) {
-                var className = "cncfmUploader_" + u.name;
-                cncfm.uploaders.activeName = u.name;
-                let config = {};
-                if (u.config) {
-                    config = u.config;
-                }
-                try {
-                    $("#cncfm-uploader-content").html(u.html);
-                    cncfm.uploaders.activeName = u.name;
-                    cncfm.uploaders.activeConf = config;
-                    cncfm.uploaders.active = eval(
-                        "new " + className + "(config)"
-                    );
-                    cncfm.uploaders.active.activate(f);
-                    cncfm.page.show("uploader");
-                } catch (err) {
-                    console.log(err);
-                    cncfm.page.notify(err.message);
-                }
+        // ------- Drag and drop logic below -------
+        $(document).on("dragenter dragover", (e) => {
+            e.preventDefault();
+
+            // Add 'dragover' class only if '#cncfm-files' is visible and '#cncfm-uploader' is not.
+            if (
+                $("#cncfm-files").is(":visible") &&
+                !$("#cncfm-uploader").is(":visible")
+            ) {
+                $("body").addClass("dragover");
             }
         });
+
+        $(document).on("dragleave drop", (e) => {
+            e.preventDefault();
+            $("body").removeClass("dragover");
+        });
+
+        $(document).on("drop", (e) => {
+            e.preventDefault();
+            $("body").removeClass("dragover");
+
+            // Accept drops only if '#cncfm-files' is visible, '#cncfm-uploader' is not, and there are actually files dropped.
+            if (
+                $("#cncfm-files").is(":visible") &&
+                !$("#cncfm-uploader").is(":visible") &&
+                e.originalEvent.dataTransfer &&
+                e.originalEvent.dataTransfer.files.length
+            ) {
+                this.changeHandler(e.originalEvent.dataTransfer.files[0]);
+            }
+        });
+
+        $(document).on("change", "#fileUpload", this.changeHandler.bind(this));
 
         cncfm.api.call("plugins/uploaders", [], function (data) {
             let seen = new Set();
@@ -82,6 +90,43 @@ class cncfmPluginsUploaders {
         });
     }
 
+    changeHandler(arg) {
+        let f;
+        if (arg instanceof File) {
+            // If 'arg' is an instance of 'File', we use it directly.
+            f = arg;
+        } else if (arg.target && arg.target.files[0]) {
+            // If 'arg' is an event object with a 'target' property,
+            // we extract the file from it.
+            f = arg.target.files[0];
+        } else {
+            // If 'arg' is neither a 'File' nor an event object with a 'target',
+            // we don't know how to handle it and thus return immediately.
+            return;
+        }
+        cncfm.uploaders.f = f;
+        var u = cncfm.uploaders.get(f);
+        if (u) {
+            var className = "cncfmUploader_" + u.name;
+            cncfm.uploaders.activeName = u.name;
+            let config = {};
+            if (u.config) {
+                config = u.config;
+            }
+            try {
+                $("#cncfm-uploader-content").html(u.html);
+                cncfm.uploaders.activeName = u.name;
+                cncfm.uploaders.activeConf = config;
+                cncfm.uploaders.active = eval("new " + className + "(config)");
+                cncfm.uploaders.active.activate(f);
+                cncfm.page.show("uploader");
+            } catch (err) {
+                console.log(err);
+                cncfm.page.notify(err.message);
+            }
+        }
+    }
+
     get(f) {
         var ext = cncfm.files.get_ext(f.name);
         if (this.uploaders[ext]) {
@@ -98,7 +143,8 @@ class cncfmPluginsUploaders {
         var uploader = cncfm.uploaders.activeName;
         var config = cncfm.uploaders.activeConf;
         var url = cncfm.api.apiUrl + "/plugins/upload";
-        var data = new FormData($("#cncfm-upload")[0]);
+        var data = new FormData();
+        data.append("fileUpload", f);
         data.set("user", cncfm.users.get_user());
         data.set("location", cncfm.files.get_location());
         data.set("uploader", uploader);

--- a/www/include/js/app.plugins.uploaders.js
+++ b/www/include/js/app.plugins.uploaders.js
@@ -35,11 +35,12 @@ class cncfmPluginsUploaders {
                     $("#cncfm-uploader-content").html(u.html);
                     cncfm.uploaders.activeName = u.name;
                     cncfm.uploaders.activeConf = config;
-                    cncfm.uploaders.active = eval("new " + className + "(config)");
+                    cncfm.uploaders.active = eval(
+                        "new " + className + "(config)"
+                    );
                     cncfm.uploaders.active.activate(f);
                     cncfm.page.show("uploader");
-                }
-                catch (err) {
+                } catch (err) {
                     console.log(err);
                     cncfm.page.notify(err.message);
                 }
@@ -52,19 +53,26 @@ class cncfmPluginsUploaders {
                 if (uploader) {
                     cncfm.uploaders.uploaders[ext] = uploader;
                     if (!seen.has(uploader.name) && uploader.js) {
-                        $("body").append($("<script />", {
-                            html: uploader.js
-                        }));
+                        $("body").append(
+                            $("<script />", {
+                                html: uploader.js,
+                            })
+                        );
                     }
                     if (!seen.has(uploader.name) && uploader.css) {
-                        $("body").append($("<style />", {
-                            html: uploader.css
-                        }));
+                        $("body").append(
+                            $("<style />", {
+                                html: uploader.css,
+                            })
+                        );
                     }
                     seen.add(uploader.name);
                 }
             });
             cncfm.uploaders.loaded = true;
+            var filetypes =
+                "." + Object.keys(cncfm.uploaders.uploaders).join(",.");
+            $("#fileUpload").attr("accept", filetypes);
         });
 
         $(window).resize(function () {


### PR DESCRIPTION
https://github.com/KnoxMakers/cncfm/assets/8474120/3586c74d-6f29-4eec-9cfd-e443c4b30309


Has the css fix from the previous pull request #3 included but additionally adds a css pseudo element at a Z-index above everything else that only displays with css if the body element has a `dragover` class applied which is handled via javascript on a drag-over event when on the files page. The exact styling may need some tweaks in terms of colors but the basic concept and functionality is there. The `onChange` event handler that previously watched for changes to the invisible file input form was broken out as its own function, `changeHandler(arg)`, which now accepts the dragged and dropped files as well. The `upload()` function now gets the file to upload from what was set in `changeHandler()` instead of again pulling from `$("#cncfm-upload")[0]` like before. 

